### PR TITLE
Improve build and update python

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -1,6 +1,3 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: Build
 
 on:
@@ -12,22 +9,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.11', '3.12' ]
-        os: [ macos-15, windows-2025 ]
+        cfg:
+          - { os: windows-2025, python-version: '3.14', architecture: x64 }
+          - { os: windows-11-arm, python-version: '3.14', architecture: arm64 }
+          - { os: macos-15, python-version: '3.14', architecture: arm64 }
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.cfg.os }}
     defaults:
       run:
         shell: bash
 
     steps:
     - name: Clone
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
+
+    - name: Setup cmake
+      uses: jwlawson/actions-setup-cmake@v2
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.cfg.python-version }}
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/python-stylecheck.yml
+++ b/.github/workflows/python-stylecheck.yml
@@ -18,16 +18,15 @@ jobs:
 
     steps:
     - name: Clone
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
-        python-version: 3.12
+        python-version: 3.14
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install black
 
     - name: run stylecheck

--- a/.github/workflows/python-unittests.yml
+++ b/.github/workflows/python-unittests.yml
@@ -1,6 +1,3 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: Unittests
 
 on:
@@ -17,23 +14,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.11', '3.12' ]
-        os: [ macos-15, windows-2025, ubuntu-24.04 ]
+        cfg:
+          - { os: windows-2025, python-version: '3.14', architecture: x64 }
+          - { os: windows-11-arm, python-version: '3.14', architecture: arm64 }
+          - { os: macos-15-intel, python-version: '3.14', architecture: x64 }
+          - { os: macos-15, python-version: '3.14', architecture: arm64 }
+          - { os: ubuntu-24.04, python-version: '3.14', architecture: x64 }
 
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    runs-on: ${{ matrix.cfg.os }}
+    timeout-minutes: 45
     defaults:
       run:
         shell: bash
 
     steps:
     - name: Clone
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
+
+    - name: Setup cmake
+      uses: jwlawson/actions-setup-cmake@v2
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.cfg.python-version }}
+        architecture: ${{ matrix.cfg.architecture }}
         
     - name: Build
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 4.1)
 
 project(amulet_zlib LANGUAGES CXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ if (MSVC)
     add_definitions("/MP")
 endif()
 
+find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+
 include(FetchContent)
 
 # Add zlib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ list(REMOVE_ITEM HEADERS ${EXTENSION_HEADERS})
 # Add implementation
 add_library(amulet_zlib SHARED)
 target_link_libraries( amulet_zlib PRIVATE zlibstatic )
+set_target_properties(amulet_zlib PROPERTIES CXX_VISIBILITY_PRESET hidden)
 set_target_properties(amulet_zlib PROPERTIES FOLDER "CPP")
 target_compile_definitions(amulet_zlib PRIVATE ExportAmuletZlib)
 target_include_directories(amulet_zlib PUBLIC ${SOURCE_PATH})
@@ -79,6 +80,7 @@ endforeach()
 
 # Add python extension
 pybind11_add_module(_amulet_zlib)
+set_target_properties(_amulet_zlib PROPERTIES CXX_VISIBILITY_PRESET hidden)
 set_target_properties(_amulet_zlib PROPERTIES FOLDER "Python")
 target_link_libraries(_amulet_zlib PRIVATE amulet_pybind11_extensions)
 target_link_libraries(_amulet_zlib PRIVATE amulet_zlib)

--- a/build_requires.py
+++ b/build_requires.py
@@ -13,7 +13,6 @@ def get_requires_for_build_wheel(
 ) -> list[str]:
     return [
         *build_meta.get_requires_for_build_wheel(config_settings),
-        "wheel",
         *requirements.get_build_dependencies(),
     ]
 

--- a/get_compiler/CMakeLists.txt
+++ b/get_compiler/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 4.1)
 
 project(get_compiler LANGUAGES CXX)
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 disallow_untyped_defs = True
 check_untyped_defs = True
 warn_return_any = True
-python_version = 3.12
+python_version = 3.14
 explicit_package_bases = True
 mypy_path = $MYPY_CONFIG_FILE_DIR/src,$MYPY_CONFIG_FILE_DIR/tests
 files = 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 description = "A Python and C++ wrapper around zlib."
 dynamic = ["version", "readme", "dependencies"]
-requires-python = ">=3.11"
+requires-python = ">=3.14"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dev = [
     "versioneer",
     "types-versioneer",
     "packaging",
-    "wheel",
     "pybind11_stubgen>=2.5.4",
     "black>=22.3",
     "isort",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,6 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-docs = [
-    "Sphinx>=1.7.4",
-    "sphinx-autodoc-typehints>=1.3.0",
-    "sphinx_rtd_theme>=0.3.1",
-]
 dev = [
     "setuptools>=42",
     "types-setuptools",
@@ -39,6 +34,11 @@ dev = [
     "mypy",
     "types-pyinstaller",
     "amulet-test-utils~=1.3",
+]
+docs = [
+    "Sphinx>=1.7.4",
+    "sphinx-autodoc-typehints>=1.3.0",
+    "sphinx_rtd_theme>=0.3.1",
 ]
 
 [project.urls]

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import platform
 from tempfile import TemporaryDirectory
 from typing import TypeAlias, TYPE_CHECKING
+import sysconfig
 
 from setuptools import setup, Extension, Command
 from setuptools.command.build_ext import build_ext
@@ -43,10 +44,14 @@ class CMakeBuild(BuildExt):
         platform_args = []
         if sys.platform == "win32":
             platform_args.extend(["-G", "Visual Studio 17 2022"])
-            if sys.maxsize > 2**32:
+            if sysconfig.get_platform() == "win-amd64":
                 platform_args.extend(["-A", "x64"])
-            else:
+            elif sysconfig.get_platform() == "win32":
                 platform_args.extend(["-A", "Win32"])
+            elif sysconfig.get_platform() == "win-arm64":
+                platform_args.extend(["-A", "ARM64"])
+            else:
+                raise RuntimeError(f"Unsupported platform: {sysconfig.get_platform()}")
             platform_args.extend(["-T", "v143"])
         elif sys.platform == "darwin":
             if platform.machine() == "arm64":

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ class CMakeBuild(BuildExt):
                 [
                     "cmake",
                     *platform_args,
-                    f"-DPYTHON_EXECUTABLE={sys.executable}",
+                    f"-DPython3_EXECUTABLE={fix_path(sys.executable)}",
                     f"-Dpybind11_DIR={fix_path(pybind11.get_cmake_dir())}",
                     f"-Damulet_pybind11_extensions_DIR={fix_path(amulet.pybind11_extensions.__path__[0])}",
                     f"-Damulet_zlib_DIR={fix_path(zlib_src_dir)}",

--- a/src/amulet/zlib/__init__.py
+++ b/src/amulet/zlib/__init__.py
@@ -13,6 +13,9 @@ def _init() -> None:
     import sys
     import ctypes
 
+    if os.environ.get("AMULET_SKIP_COMPILE", None):
+        return
+
     if sys.platform == "win32":
         lib_path = os.path.join(os.path.dirname(__file__), "amulet_zlib.dll")
     elif sys.platform == "darwin":

--- a/src/amulet/zlib/__init__.py
+++ b/src/amulet/zlib/__init__.py
@@ -34,3 +34,4 @@ def _init() -> None:
 
 
 _init()
+del _init

--- a/src/amulet/zlib/__init__.py
+++ b/src/amulet/zlib/__init__.py
@@ -1,22 +1,8 @@
-from typing import TYPE_CHECKING
 import logging as _logging
 
 from . import _version
 
 __version__ = _version.get_versions()["version"]
-
-if TYPE_CHECKING:
-
-    class ZipBombException(RuntimeError):
-        pass
-
-    def get_max_decompression_size() -> int: ...
-    def set_max_decompression_size(max_decompression_size: int) -> None: ...
-
-    def decompress_zlib_gzip(src: bytes) -> bytes: ...
-    def compress_zlib(src: bytes) -> bytes: ...
-    def compress_gzip(src: bytes) -> bytes: ...
-
 
 # init a default logger
 _logging.basicConfig(level=_logging.INFO, format="%(levelname)s - %(message)s")

--- a/src/amulet/zlib/_amulet_zlib.py.cpp
+++ b/src/amulet/zlib/_amulet_zlib.py.cpp
@@ -2,65 +2,18 @@
 
 #include <amulet/pybind11_extensions/compatibility.hpp>
 
-#include <amulet/zlib/zlib.hpp>
-
 namespace py = pybind11;
 namespace pyext = Amulet::pybind11_extensions;
 
-void init_module(py::module m)
+void init_amulet_zlib(py::module);
+
+static void _init_amulet_zlib(py::module m)
 {
     pyext::init_compiler_config(m);
-
-    py::register_exception<Amulet::zlib::ZipBombException>(m, "ZipBombException");
-
-    m.def(
-        "get_max_decompression_size",
-        &Amulet::zlib::get_max_decompression_size,
-        py::doc("Get the configured maximum decompressed size in bytes. (Default 100MB)"));
-    m.def(
-        "set_max_decompression_size",
-        &Amulet::zlib::set_max_decompression_size,
-        py::doc(
-            "Set the configured maximum decompressed size in bytes.\n"
-            "If decompression requires more memory than this it will raise ZipBombException."));
-
-    m.def(
-        "decompress_zlib_gzip",
-        [](py::bytes src) {
-            std::string dst;
-            {
-                py::gil_scoped_release nogil;
-                Amulet::zlib::decompress_zlib_gzip(src, dst);
-            }
-            return py::bytes(dst);
-        },
-        py::doc(
-            "Decompress a bytes object compressed with either zlib or gzip.\n"
-            "Raises ZipBombException if decompression requires more than the configured maximum decompression size."));
-    m.def(
-        "compress_zlib",
-        [](py::bytes src) {
-            std::string dst;
-            {
-                py::gil_scoped_release nogil;
-                Amulet::zlib::compress_zlib(src, dst);
-            }
-            return py::bytes(dst);
-        },
-        py::doc("Compress a bytes object using the zlib compression format."));
-    m.def(
-        "compress_gzip",
-        [](py::bytes src) {
-        std::string dst;
-        {
-            py::gil_scoped_release nogil;
-            Amulet::zlib::compress_gzip(src, dst);
-        }
-        return py::bytes(dst); },
-        py::doc("Compress a bytes object using the gzip compression format."));
+    init_amulet_zlib(m);
 }
 
 PYBIND11_MODULE(_amulet_zlib, m)
 {
-    m.def("init", &init_module, py::arg("m"));
+    m.def("init", &_init_amulet_zlib, py::arg("m"));
 }

--- a/src/amulet/zlib/_amulet_zlib_.py.cpp
+++ b/src/amulet/zlib/_amulet_zlib_.py.cpp
@@ -1,0 +1,56 @@
+#include <pybind11/pybind11.h>
+
+#include <amulet/zlib/zlib.hpp>
+
+namespace py = pybind11;
+
+void init_amulet_zlib(py::module m)
+{
+    py::register_exception<Amulet::zlib::ZipBombException>(m, "ZipBombException");
+
+    m.def(
+        "get_max_decompression_size",
+        &Amulet::zlib::get_max_decompression_size,
+        py::doc("Get the configured maximum decompressed size in bytes. (Default 100MB)"));
+    m.def(
+        "set_max_decompression_size",
+        &Amulet::zlib::set_max_decompression_size,
+        py::doc(
+            "Set the configured maximum decompressed size in bytes.\n"
+            "If decompression requires more memory than this it will raise ZipBombException."));
+
+    m.def(
+        "decompress_zlib_gzip",
+        [](py::bytes src) {
+            std::string dst;
+            {
+                py::gil_scoped_release nogil;
+                Amulet::zlib::decompress_zlib_gzip(src, dst);
+            }
+            return py::bytes(dst);
+        },
+        py::doc(
+            "Decompress a bytes object compressed with either zlib or gzip.\n"
+            "Raises ZipBombException if decompression requires more than the configured maximum decompression size."));
+    m.def(
+        "compress_zlib",
+        [](py::bytes src) {
+            std::string dst;
+            {
+                py::gil_scoped_release nogil;
+                Amulet::zlib::compress_zlib(src, dst);
+            }
+            return py::bytes(dst);
+        },
+        py::doc("Compress a bytes object using the zlib compression format."));
+    m.def(
+        "compress_gzip",
+        [](py::bytes src) {
+        std::string dst;
+        {
+            py::gil_scoped_release nogil;
+            Amulet::zlib::compress_gzip(src, dst);
+        }
+        return py::bytes(dst); },
+        py::doc("Compress a bytes object using the gzip compression format."));
+}

--- a/src/amulet/zlib/export.hpp
+++ b/src/amulet/zlib/export.hpp
@@ -8,14 +8,6 @@
             #define AMULET_ZLIB_EXPORT __declspec(dllimport)
         #endif
     #else
-        #define AMULET_ZLIB_EXPORT
-    #endif
-#endif
-
-#if !defined(AMULET_ZLIB_EXPORT_EXCEPTION)
-    #if defined(__GNUC__) || defined(__clang__)
-        #define AMULET_ZLIB_EXPORT_EXCEPTION __attribute__((visibility("default")))
-    #else
-        #define AMULET_ZLIB_EXPORT_EXCEPTION
+        #define AMULET_ZLIB_EXPORT __attribute__((visibility("default")))
     #endif
 #endif

--- a/src/amulet/zlib/export.hpp
+++ b/src/amulet/zlib/export.hpp
@@ -13,7 +13,7 @@
 #endif
 
 #if !defined(AMULET_ZLIB_EXPORT_EXCEPTION)
-    #if defined(_LIBCPP_EXCEPTION)
+    #if defined(__GNUC__) || defined(__clang__)
         #define AMULET_ZLIB_EXPORT_EXCEPTION __attribute__((visibility("default")))
     #else
         #define AMULET_ZLIB_EXPORT_EXCEPTION

--- a/src/amulet/zlib/zlib.cpp
+++ b/src/amulet/zlib/zlib.cpp
@@ -15,9 +15,7 @@ static_assert(DST_CHUNK_SIZE <= std::numeric_limits<uInt>::max());
 namespace Amulet {
 namespace zlib {
 
-    ZipBombException::ZipBombException(const std::string& what_arg) : std::runtime_error(what_arg) {}
-    ZipBombException::ZipBombException(const char* what_arg) : std::runtime_error(what_arg) {}
-    ZipBombException::ZipBombException(const ZipBombException& other) noexcept : std::runtime_error(other) {}
+    ZipBombException::~ZipBombException() noexcept {}
 
     static size_t _max_decompression_size = 100000000; // 100MB
 

--- a/src/amulet/zlib/zlib.cpp
+++ b/src/amulet/zlib/zlib.cpp
@@ -15,6 +15,10 @@ static_assert(DST_CHUNK_SIZE <= std::numeric_limits<uInt>::max());
 namespace Amulet {
 namespace zlib {
 
+    ZipBombException::ZipBombException(const std::string& what_arg) : std::runtime_error(what_arg) {}
+    ZipBombException::ZipBombException(const char* what_arg) : std::runtime_error(what_arg) {}
+    ZipBombException::ZipBombException(const ZipBombException& other) noexcept : std::runtime_error(other) {}
+
     static size_t _max_decompression_size = 100000000; // 100MB
 
     size_t get_max_decompression_size()

--- a/src/amulet/zlib/zlib.hpp
+++ b/src/amulet/zlib/zlib.hpp
@@ -11,9 +11,8 @@ namespace zlib {
 
     class AMULET_ZLIB_EXPORT ZipBombException : public std::runtime_error {
     public:
-        ZipBombException(const std::string& what_arg);
-        ZipBombException(const char* what_arg);
-        ZipBombException(const ZipBombException& other) noexcept;
+        using std::runtime_error::runtime_error;
+        virtual ~ZipBombException() noexcept;
     };
 
     // Get the configured maximum decompressed size in bytes. (Default 100MB)

--- a/src/amulet/zlib/zlib.hpp
+++ b/src/amulet/zlib/zlib.hpp
@@ -9,9 +9,11 @@
 namespace Amulet {
 namespace zlib {
 
-    class AMULET_ZLIB_EXPORT_EXCEPTION ZipBombException : public std::runtime_error {
+    class AMULET_ZLIB_EXPORT ZipBombException : public std::runtime_error {
     public:
-        using std::runtime_error::runtime_error;
+        ZipBombException(const std::string& what_arg);
+        ZipBombException(const char* what_arg);
+        ZipBombException(const ZipBombException& other) noexcept;
     };
 
     // Get the configured maximum decompressed size in bytes. (Default 100MB)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,8 @@ else()
     message( FATAL_ERROR "Unsupported platform. Please submit a pull request to support this platform." )
 endif()
 
+find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+
 # Find dependencies
 if (NOT TARGET pybind11::module)
     find_package(pybind11 CONFIG REQUIRED)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ endif()
 file(GLOB_RECURSE SOURCES LIST_DIRECTORIES false "${CMAKE_CURRENT_LIST_DIR}/*.py.cpp")
 
 pybind11_add_module(_test_amulet_zlib)
+set_target_properties(_test_amulet_zlib PROPERTIES CXX_VISIBILITY_PRESET hidden)
 set_target_properties(_test_amulet_zlib PROPERTIES FOLDER "Tests")
 target_compile_definitions(_test_amulet_zlib PRIVATE PYBIND11_DETAILED_ERROR_MESSAGES)
 target_compile_definitions(_test_amulet_zlib PRIVATE PYBIND11_VERSION="${pybind11_VERSION}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 4.1)
 
 project(amulet_zlib_tests LANGUAGES CXX)
 

--- a/tests/test_amulet_zlib/_test_amulet_zlib.py.cpp
+++ b/tests/test_amulet_zlib/_test_amulet_zlib.py.cpp
@@ -5,15 +5,14 @@
 namespace py = pybind11;
 namespace pyext = Amulet::pybind11_extensions;
 
-void init_test_zlib(py::module);
+void init_test_amulet_zlib(py::module);
 
-void init_module(py::module m){
+static void _init_test_amulet_zlib(py::module m){
     pyext::init_compiler_config(m);
     pyext::check_compatibility(py::module::import("amulet.zlib"), m);
-
-    init_test_zlib(m);
+    init_test_amulet_zlib(m);
 }
 
 PYBIND11_MODULE(_test_amulet_zlib, m) {
-    m.def("init", &init_module, py::arg("m"));
+    m.def("init", &_init_test_amulet_zlib, py::arg("m"));
 }

--- a/tests/test_amulet_zlib/test_zlib_.py.cpp
+++ b/tests/test_amulet_zlib/test_zlib_.py.cpp
@@ -9,7 +9,7 @@
 
 namespace py = pybind11;
 
-void init_test_zlib(py::module m_parent)
+void init_test_amulet_zlib(py::module m_parent)
 {
     auto m = m_parent.def_submodule("test_zlib_");
 

--- a/tools/cmake_generate.py
+++ b/tools/cmake_generate.py
@@ -34,7 +34,7 @@ def main() -> None:
         [
             "cmake",
             *platform_args,
-            f"-DPYTHON_EXECUTABLE={sys.executable}",
+            f"-DPython3_EXECUTABLE={fix_path(sys.executable)}",
             f"-Dpybind11_DIR={fix_path(pybind11.get_cmake_dir())}",
             f"-Damulet_pybind11_extensions_DIR={fix_path(amulet.pybind11_extensions.__path__[0])}",
             f"-Damulet_test_utils_DIR={fix_path(amulet.test_utils.__path__[0])}",

--- a/tools/cmake_generate.py
+++ b/tools/cmake_generate.py
@@ -2,6 +2,7 @@ import sys
 import subprocess
 import os
 import shutil
+import sysconfig
 
 import pybind11
 import amulet.pybind11_extensions
@@ -19,10 +20,14 @@ def main() -> None:
     platform_args = []
     if sys.platform == "win32":
         platform_args.extend(["-G", "Visual Studio 17 2022"])
-        if sys.maxsize > 2**32:
+        if sysconfig.get_platform() == "win-amd64":
             platform_args.extend(["-A", "x64"])
-        else:
+        elif sysconfig.get_platform() == "win32":
             platform_args.extend(["-A", "Win32"])
+        elif sysconfig.get_platform() == "win-arm64":
+            platform_args.extend(["-A", "ARM64"])
+        else:
+            raise RuntimeError(f"Unsupported platform: {sysconfig.get_platform()}")
         platform_args.extend(["-T", "v143"])
 
     os.chdir(RootDir)

--- a/tools/compile_tests.py
+++ b/tools/compile_tests.py
@@ -36,7 +36,7 @@ def main() -> None:
         [
             "cmake",
             *platform_args,
-            f"-DPYTHON_EXECUTABLE={sys.executable}",
+            f"-DPython3_EXECUTABLE={fix_path(sys.executable)}",
             f"-Dpybind11_DIR={fix_path(pybind11.get_cmake_dir())}",
             f"-Damulet_pybind11_extensions_DIR={fix_path(amulet.pybind11_extensions.__path__[0])}",
             f"-Damulet_test_utils_DIR={fix_path(amulet.test_utils.__path__[0])}",

--- a/tools/compile_tests.py
+++ b/tools/compile_tests.py
@@ -2,6 +2,7 @@ import subprocess
 import sys
 import shutil
 import os
+import sysconfig
 
 import pybind11
 import amulet.pybind11_extensions
@@ -21,10 +22,14 @@ def main() -> None:
     platform_args = []
     if sys.platform == "win32":
         platform_args.extend(["-G", "Visual Studio 17 2022"])
-        if sys.maxsize > 2**32:
+        if sysconfig.get_platform() == "win-amd64":
             platform_args.extend(["-A", "x64"])
-        else:
+        elif sysconfig.get_platform() == "win32":
             platform_args.extend(["-A", "Win32"])
+        elif sysconfig.get_platform() == "win-arm64":
+            platform_args.extend(["-A", "ARM64"])
+        else:
+            raise RuntimeError(f"Unsupported platform: {sysconfig.get_platform()}")
         platform_args.extend(["-T", "v143"])
 
     os.chdir(TestsDir)

--- a/tools/generate_pybind_stubs.py
+++ b/tools/generate_pybind_stubs.py
@@ -8,7 +8,6 @@ import pybind11_stubgen
 from pybind11_stubgen.structs import Identifier
 from pybind11_stubgen.parser.mixins.filter import FilterClassMembers
 
-
 ForwardRefPattern = re.compile(r"ForwardRef\('(?P<variable>[a-zA-Z_][a-zA-Z0-9_]*)'\)")
 
 QuotePattern = re.compile(r"'(?P<variable>[a-zA-Z_][a-zA-Z0-9_]*)'")

--- a/tools/generate_pybind_stubs.py
+++ b/tools/generate_pybind_stubs.py
@@ -8,6 +8,7 @@ import pybind11_stubgen
 from pybind11_stubgen.structs import Identifier
 from pybind11_stubgen.parser.mixins.filter import FilterClassMembers
 
+
 ForwardRefPattern = re.compile(r"ForwardRef\('(?P<variable>[a-zA-Z_][a-zA-Z0-9_]*)'\)")
 
 QuotePattern = re.compile(r"'(?P<variable>[a-zA-Z_][a-zA-Z0-9_]*)'")


### PR DESCRIPTION
Update and improve build workflows.
Add more platforms to tests.
Update cmake.
Remove redundant type hints.
Move library implementation out of generated code.
Fix exception duplication.